### PR TITLE
Add AIRAC pre-release cycle automation

### DIFF
--- a/.github/workflows/airac-prerelease.yml
+++ b/.github/workflows/airac-prerelease.yml
@@ -5,6 +5,9 @@ name: AIRAC Pre-release Cycle
 # exactly 28 days apart from AIRAC 2601 = 2026-01-22, so every date here is
 # COMPUTED, never looked up):
 #
+#   * Wed (T-8)    — "finalise your pull requests, PR review starts Friday", to
+#                    the contributors channel. A heads-up to PR authors two days
+#                    before the Friday review begins.
 #   * Friday (T-6) — "review & merge open pull requests before the freeze": the
 #                    pre-AIRAC warning + org-wide open-PR list, to the staff
 #                    channel. Moved forward from the Monday tracker report so PRs
@@ -30,9 +33,10 @@ name: AIRAC Pre-release Cycle
 
 on:
   schedule:
-    - cron: "0 9 * * 5" # Fridays 09:00 UTC  — merge-your-PRs warning (T-6)
-    - cron: "0 9 * * 0" # Sundays 09:00 UTC  — cut the pre-release     (T-4)
-    - cron: "0 9 * * 2" # Tuesdays 09:00 UTC — finalise-testing nudge  (T-2)
+    - cron: "0 9 * * 3" # Wednesdays 09:00 UTC — finalise-PRs heads-up   (T-8)
+    - cron: "0 9 * * 5" # Fridays 09:00 UTC    — merge-your-PRs warning  (T-6)
+    - cron: "0 9 * * 0" # Sundays 09:00 UTC    — cut the pre-release     (T-4)
+    - cron: "0 9 * * 2" # Tuesdays 09:00 UTC   — finalise-testing nudge  (T-2)
   issues:
     # Ticking a sector on the prep issue refreshes the progress message and, once
     # all are ticked, fires the ready-to-test ping. Every issue edit in the repo
@@ -45,7 +49,7 @@ on:
         required: false
         default: auto
         type: choice
-        options: [auto, friday, sunday, tuesday]
+        options: [auto, wednesday, friday, sunday, tuesday]
       airac_cycle:
         description: "AIRAC cycle to act on (YYNN, e.g. 2607). Empty = the next upcoming cycle."
         required: false
@@ -112,10 +116,11 @@ jobs:
               else:
                   phase = "ignore"
           else:
-              # The upcoming cycle and how far out its Thursday is. On the three
-              # days we care about that Thursday is 6 / 4 / 2 days away; on the OTHER
-              # Fridays, Sundays and Tuesdays in a 28-day cycle it is 13/20/27,
-              # 11/18/25 and 9/16/23 — so the day-count uniquely identifies the week.
+              # The upcoming cycle and how far out its Thursday is. On the four days
+              # we care about that Thursday is 8 / 6 / 4 / 2 days away; on the OTHER
+              # Wednesdays, Fridays, Sundays and Tuesdays in a 28-day cycle it is
+              # 1/15/22, 13/20/27, 11/18/25 and 9/16/23 — so the day-count uniquely
+              # identifies the right week.
               if override:
                   cdate = date_for_cycle(override)
                   if cdate is None:
@@ -126,7 +131,9 @@ jobs:
 
               weekday = today.weekday()  # Mon=0 ... Sun=6
               auto = "none"
-              if weekday == 4 and days == 6:
+              if weekday == 2 and days == 8:
+                  auto = "wednesday"
+              elif weekday == 4 and days == 6:
                   auto = "friday"
               elif weekday == 6 and days == 4:
                   auto = "sunday"
@@ -153,6 +160,51 @@ jobs:
           print(f"Phase : {phase}" + (" (forced)" if forced != "auto" else ""))
           print(f"Cycle : {cycle} on {cdate} — {days} day(s) out")
           PYEOF
+
+  # ── Wednesday (T-8): finalise-your-PRs heads-up ─────────────────────────────
+  finalise-prs:
+    name: Wednesday — finalise your pull requests
+    needs: prepare
+    if: needs.prepare.outputs.phase == 'wednesday'
+    runs-on: ubuntu-latest
+    env:
+      # A dedicated contributors channel — set DISCORD_CONTRIBUTORS_WEBHOOK to its
+      # webhook URL. Distinct from the staff channel the other phases post to.
+      WEBHOOK: ${{ secrets.DISCORD_CONTRIBUTORS_WEBHOOK }}
+      ORG: ${{ github.repository_owner }}
+      CYCLE: ${{ needs.prepare.outputs.cycle }}
+      HUMAN: ${{ needs.prepare.outputs.human }}
+    steps:
+      - name: Post the finalise-your-PRs heads-up
+        run: |
+          set -euo pipefail
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "::warning::DISCORD_CONTRIBUTORS_WEBHOOK not set — no heads-up sent."
+            exit 0
+          fi
+
+          python3 - > /tmp/payload.json << 'PYEOF'
+          import json, os
+
+          org = os.environ["ORG"]
+          cycle = os.environ["CYCLE"]
+          print(json.dumps({
+              "username": os.environ["BOT_NAME"],
+              "avatar_url": os.environ["BOT_ICON"],
+              "embeds": [{
+                  "title": f"Finalise your pull requests — AIRAC {cycle} review starts Friday",
+                  "url": f"https://github.com/pulls?q=is%3Aopen+is%3Apr+org%3A{org}+archived%3Afalse",
+                  "color": 16426522,
+                  "description": (
+                      f"PR review for AIRAC {cycle} (effective **{os.environ['HUMAN']}**) begins "
+                      f"**this Friday**. Please finish anything you want reviewed and open it for "
+                      f"review in the next few days — the pre-release is cut on Sunday, and "
+                      f"whatever is not merged by then rolls to the next cycle."
+                  ),
+              }],
+          }))
+          PYEOF
+          curl -sS -H "Content-Type: application/json" -X POST "$WEBHOOK" -d @/tmp/payload.json
 
   # ── Friday (T-6): merge-your-PRs warning ────────────────────────────────────
   nag:


### PR DESCRIPTION
Adds airac-prerelease.yml running the pre-release phase before each AIRAC Thursday: Wednesday (T-8) finalise-your-PRs heads-up to the contributors channel; Friday (T-6) merge warning + open-PR list to staff; Sunday (T-4) cut RC prereleases + open the prep issue + live staff progress board (no ping); ready-to-test testers ping when all sectors are ticked, which closes the prep issue; Tuesday (T-2) finalise-testing nudge. Also: airac-tracker.yml drops the pre-AIRAC warning (moved to Friday) and keeps the weekly open-PR list; create-airac-milestone-release.yml backstop-closes the prep issue on the AIRAC date. Needs a new repo secret DISCORD_CONTRIBUTORS_WEBHOOK for the Wednesday message.