### PR TITLE
fix(vatis): attach profiles to the release that was just cut

### DIFF
--- a/.github/workflows/airac-prerelease.yml
+++ b/.github/workflows/airac-prerelease.yml
@@ -327,6 +327,7 @@ jobs:
 
       - name: Cut the pre-release
         if: steps.guard.outputs.skip == 'false'
+        id: release
         run: |
           set -euo pipefail
 
@@ -358,19 +359,23 @@ jobs:
             -F prerelease=true \
             -F generate_release_notes=true >/dev/null
 
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Cut pre-release '$NAME' ($TAG)"
 
       - name: Attach the vATIS profile to the pre-release
         # Testers need the complete package, so the RC carries the vATIS profile
         # exactly like a final release does.
         if: steps.guard.outputs.skip == 'false' && env.HAS_VATIS == 'true'
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
-          YY="${AIRAC_CYCLE:0:2}"
-          NN="${AIRAC_CYCLE:2:2}"
-          BASE="v${YY}.${NN}.1"
-          TAG=$(gh api "repos/$REPO/releases?per_page=100" --paginate \
-                  --jq "[.[] | .tag_name | select(startswith(\"${BASE}-rc\"))] | sort_by(ltrimstr(\"${BASE}-rc\") | tonumber) | last // empty")
+
+          # The tag comes from the step that just cut it, never from re-listing
+          # releases. GitHub's release list is stale for a few seconds after a
+          # POST, which is what silently attached every final-release profile to
+          # the PREVIOUS tag on 2026-07-17 and 404'd every download button.
+          TAG="${RELEASE_TAG:-}"
           if [ -z "$TAG" ]; then
             echo "::warning::No pre-release for AIRAC $AIRAC_CYCLE — nothing to attach to."
             exit 0
@@ -383,8 +388,21 @@ jobs:
           fi
 
           curl -sSfL "$URL" -o "/tmp/${CODE}.json"
-          python3 -c "import json,sys; json.load(open(sys.argv[1]))" "/tmp/${CODE}.json" \
-            || { echo "::error::vATIS/${CODE}.json is not valid JSON"; exit 1; }
+          # Valid JSON is not enough: sectorfile-fywf shipped a profile whose
+          # `stations` array was empty, which imports into vATIS as a profile
+          # with nothing in it. Refuse to publish one.
+          python3 - "/tmp/${CODE}.json" <<'PYEOF' || exit 1
+          import json, sys
+          try:
+              profile = json.load(open(sys.argv[1]))
+          except Exception as exc:
+              print(f"::error::vATIS profile is not valid JSON: {exc}")
+              sys.exit(1)
+          if not profile.get("stations"):
+              print("::error::vATIS profile has no stations. It is an empty stub. "
+                    "Clear 'vatis' in sectors.yml until a real profile exists.")
+              sys.exit(1)
+          PYEOF
 
           gh release upload "$TAG" "/tmp/${CODE}.json" --repo "$REPO" --clobber
           echo "Attached ${CODE}.json to $TAG"

--- a/.github/workflows/create-airac-milestone-release.yml
+++ b/.github/workflows/create-airac-milestone-release.yml
@@ -362,6 +362,7 @@ jobs:
 
       - name: Create release
         if: steps.guard.outputs.skip == 'false'
+        id: release
         run: |
           set -euo pipefail
 
@@ -378,6 +379,9 @@ jobs:
           if [ "$LATEST" -gt 0 ] && [ "$NEW_REVISION" != "true" ]; then
             echo "v${YY}.${NN}.${LATEST} already exists for AIRAC $AIRAC_CYCLE — skipping."
             echo "Re-run with new_revision: true to cut #$((LATEST + 1))."
+            # Still publish the tag, so a re-run back-fills the vATIS asset onto
+            # the release that already exists instead of attaching nothing.
+            echo "tag=v${YY}.${NN}.${LATEST}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -409,22 +413,28 @@ jobs:
             -F prerelease=false \
             -F generate_release_notes=true >/dev/null
 
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Created release '$NAME' ($TAG)"
 
       - name: Attach the vATIS profile to the release
         # Runs even when the release already existed, so re-running a cycle
         # back-fills assets onto releases cut before this step existed.
         if: steps.guard.outputs.skip == 'false' && env.HAS_VATIS == 'true'
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
 
           # The board links to /releases/latest/download/<CODE>.json. That only
           # downloads (rather than rendering as text) because release assets send
           # Content-Disposition: attachment — a raw.githubusercontent URL does not.
-          YY="${AIRAC_CYCLE:0:2}"
-          NN="${AIRAC_CYCLE:2:2}"
-          TAG=$(gh api "repos/$REPO/releases?per_page=100" --paginate \
-                  --jq "[.[] | .tag_name | select(startswith(\"v${YY}.${NN}.\"))] | sort | last // empty")
+          # The tag comes from the step that just settled on it. It must NOT be
+          # re-derived by listing releases: GitHub's release list is stale for a
+          # few seconds after a POST, so on 2026-07-17 every sector attached its
+          # profile to the PREVIOUS release — HKNA.json landed on v26.07.1 four
+          # seconds after v26.07.2 was published. /releases/latest then resolves
+          # to the newer, asset-less release and every download button 404s.
+          TAG="${RELEASE_TAG:-}"
           if [ -z "$TAG" ]; then
             echo "::warning::No release for AIRAC $AIRAC_CYCLE — nothing to attach to."
             exit 0
@@ -437,8 +447,21 @@ jobs:
           fi
 
           curl -sSfL "$URL" -o "/tmp/${CODE}.json"
-          python3 -c "import json,sys; json.load(open(sys.argv[1]))" "/tmp/${CODE}.json" \
-            || { echo "::error::vATIS/${CODE}.json is not valid JSON"; exit 1; }
+          # Valid JSON is not enough: sectorfile-fywf shipped a profile whose
+          # `stations` array was empty, which imports into vATIS as a profile
+          # with nothing in it. Refuse to publish one.
+          python3 - "/tmp/${CODE}.json" <<'PYEOF' || exit 1
+          import json, sys
+          try:
+              profile = json.load(open(sys.argv[1]))
+          except Exception as exc:
+              print(f"::error::vATIS profile is not valid JSON: {exc}")
+              sys.exit(1)
+          if not profile.get("stations"):
+              print("::error::vATIS profile has no stations. It is an empty stub. "
+                    "Clear 'vatis' in sectors.yml until a real profile exists.")
+              sys.exit(1)
+          PYEOF
 
           gh release upload "$TAG" "/tmp/${CODE}.json" --repo "$REPO" --clobber
           echo "Attached ${CODE}.json to $TAG"

--- a/repository-management/sectors.yml
+++ b/repository-management/sectors.yml
@@ -72,6 +72,11 @@ sectors:
     region: Southern Africa
 
   # ⚠️ repo suffix (fywf) deliberately differs from the code (FYWH).
+  # No `vatis` flag on purpose. The repo does carry vATIS/FYWF.json, and the old
+  # PHP site offered it as a download, but the file is an EMPTY STUB — its
+  # `stations` array has zero entries, so importing it gives a controller a
+  # profile with nothing in it. Set the flag once a real profile exists, and
+  # name it FYWH.json to match `code` above.
   - repo: sectorfile-fywf
     code: FYWH
     name: FYWH Windhoek
@@ -147,6 +152,7 @@ sectors:
 
   - repo: sectorfile-fzza
     code: FZZA
+    vatis: true
     name: FZZA Kinshasa
     region: Central Africa
 


### PR DESCRIPTION
Every vATIS download button on the site has 404'd since 17 July.

The attach step re-queried the releases list to work out which tag to upload
to. GitHub's list-releases endpoint is stale for a few seconds after a POST,
so it never saw the release the same job had just created and picked the
previous one. The 17 July logs show it plainly: sectorfile-hkna published
v26.07.2 at 20:21:23 and logged "Attached HKNA.json to v26.07.1" at 20:21:27,
four seconds later. /releases/latest resolves to the newer, asset-less
release, so every link 404s. The workflow reported success throughout, because
the upload genuinely worked. It just landed on the wrong tag.

The create step now publishes the tag it settled on and the attach step
consumes it. Both branches emit it, so re-running a cycle whose release
already exists back-fills the asset rather than attaching nothing, which is
what the step's own comment always claimed it did.

Same fix in airac-prerelease.yml, which had the identical bug.

Also refuses to publish an empty profile. Valid JSON was the only check, and
sectorfile-fywf carries a vATIS/FYWF.json whose `stations` array is empty --
importing it hands a controller a profile with nothing in it. The old PHP site
offered that file as a download.

sectors.yml: FZZA gains `vatis: true`. Its profile is real (FZAA Kinshasa
N'Djili) and was simply sitting in a folder nothing reads. FYWH deliberately
does NOT gain the flag, for the empty-stub reason above; the comment records
what has to happen before it can.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
